### PR TITLE
Generic defaultKey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,15 @@
 All notable changes to this project will be documented in this file.
 `Defaults.swift` adheres to [Semantic Versioning](http://semver.org/).
 
+#### 2.x Releases
+- `1.0.x` Releases - [2.0.0](#200)
+
 #### 1.x Releases
 - `1.0.x` Releases - [1.0.0](#100)
+
+## [2.0.0](https://github.com/dalu93/Defaults/releases/tag/2.0.0)
+- [DefaultKey is generic over the type the user wants to store](https://github.com/dalu93/Defaults/issues/1)
+Released on 2016-10-19
 
 ## [1.0.0](https://github.com/dalu93/Defaults/releases/tag/1.0.0)
 Released on 2016-10-14.

--- a/Defaults.swift.podspec
+++ b/Defaults.swift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name = 'Defaults.swift'
-    s.version = '1.0.0'
+    s.version = '2.0.0'
     s.license = 'MIT'
     s.summary = 'Easy to use UserDefaults for iOS apps.'
     s.homepage = 'https://github.com/dalu93/Defaults'

--- a/Defaults/ViewController.swift
+++ b/Defaults/ViewController.swift
@@ -22,13 +22,16 @@ class ViewController: UIViewController {
     
     func examples() {
         
-        let defaultKey = DefaultKey.Name(rawValue: "key")!
+        let defaultKey = DefaultKey<String>("key")
         
         // Get the string value for the key. The method returns an Optional
-        let storedString: String? = UserDefaults.standard.get(for: defaultKey)
+        let storedString = UserDefaults.standard.get(for: defaultKey)
         
         // Store a new value
         UserDefaults.standard.set("hello", for: defaultKey)
+        
+        // By trying to set a different type, the compiler will throw
+//        UserDefaults.standard.set(10, for: defaultKey)
         
         // Delete the value from the storage
         UserDefaults.standard.set(nil, for: defaultKey)
@@ -40,7 +43,7 @@ class ViewController: UIViewController {
         var stringDefaults = Defaults<String>.standard
         
         // Get the string value for the key. Returns an Optional
-        let storedValue = stringDefaults[defaultKey]    // storedValue is a String?
+        let storedValue = stringDefaults[defaultKey]
         
         // Store a new value
         stringDefaults[defaultKey] = "hello"

--- a/DefaultsTests/DefaultsTests.swift
+++ b/DefaultsTests/DefaultsTests.swift
@@ -11,7 +11,7 @@ import XCTest
 
 class DefaultsTests: XCTestCase {
     
-    let defaultKey = DefaultKey.Name(rawValue: "key")!
+    let defaultKey = DefaultKey<String>("key")
     var stringDefaults = Defaults<String>.standard
     
     override func setUp() {
@@ -20,7 +20,7 @@ class DefaultsTests: XCTestCase {
     
     override func tearDown() {
         super.tearDown()
-        UserDefaults.standard.removeObject(forKey: defaultKey.rawValue)
+        UserDefaults.standard.removeObject(forKey: defaultKey.name)
         UserDefaults.standard.synchronize()
     }
     
@@ -29,9 +29,9 @@ class DefaultsTests: XCTestCase {
         
         UserDefaults.standard.set(newValue, for: defaultKey)
         
-        let storedValue = UserDefaults.standard.string(forKey: defaultKey.rawValue)
+        let storedValue = UserDefaults.standard.string(forKey: defaultKey.name)
         
-        XCTAssert(storedValue == newValue, "The stored value for the key \(defaultKey.rawValue) is different from \(newValue)")
+        XCTAssert(storedValue == newValue, "The stored value for the key \(defaultKey.name) is different from \(newValue)")
     }
     
     func testStoreNewValueWithSecondInterface() {
@@ -39,15 +39,15 @@ class DefaultsTests: XCTestCase {
         
         stringDefaults[defaultKey] = newValue
         
-        let storedValue = UserDefaults.standard.string(forKey: defaultKey.rawValue)
+        let storedValue = UserDefaults.standard.string(forKey: defaultKey.name)
         
-        XCTAssert(storedValue == newValue, "The stored value for the key \(defaultKey.rawValue) is different from \(newValue)")
+        XCTAssert(storedValue == newValue, "The stored value for the key \(defaultKey.name) is different from \(newValue)")
     }
     
     func testGetValueFirstInterface() {
         let storedValue = "fhdifhsif"
         
-        UserDefaults.standard.set(storedValue, forKey: defaultKey.rawValue)
+        UserDefaults.standard.set(storedValue, forKey: defaultKey.name)
         UserDefaults.standard.synchronize()
         
         let retrievedValue: String = UserDefaults.standard.get(for: defaultKey)!
@@ -58,7 +58,7 @@ class DefaultsTests: XCTestCase {
     func testGetValueSecondInterface() {
         let storedValue = "fhdifhsif"
         
-        UserDefaults.standard.set(storedValue, forKey: defaultKey.rawValue)
+        UserDefaults.standard.set(storedValue, forKey: defaultKey.name)
         UserDefaults.standard.synchronize()
         
         let retrievedValue = stringDefaults[defaultKey]!
@@ -69,7 +69,7 @@ class DefaultsTests: XCTestCase {
     func testDeleteValueFirstInterface() {
         let storedValue = "fhdifhsif"
         
-        UserDefaults.standard.set(storedValue, forKey: defaultKey.rawValue)
+        UserDefaults.standard.set(storedValue, forKey: defaultKey.name)
         UserDefaults.standard.synchronize()
         
         UserDefaults.standard.set(nil, for: defaultKey)
@@ -82,7 +82,7 @@ class DefaultsTests: XCTestCase {
     func testDeleteValueSecondInterface() {
         let storedValue = "fhdifhsif"
         
-        UserDefaults.standard.set(storedValue, forKey: defaultKey.rawValue)
+        UserDefaults.standard.set(storedValue, forKey: defaultKey.name)
         UserDefaults.standard.synchronize()
         
         stringDefaults[defaultKey] = nil

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Defaults.swift is a easy-to-use generic interface built on top of `UserDefaults`
 - [Requirements](#requirements)
 - [Installation](#installation)
 - [Usage](#usage)
+- [Migration](#migration)
 - [License](#license)
 
 ## Features
@@ -60,17 +61,17 @@ $ pod install
 
 ### Define the keys
 
-`Defaults.swift` uses a structure called `DefaultKey.Name` to handle the `UserDefaults` keys.
+`Defaults.swift` uses a structure called `DefaultKey<T>` to handle the `UserDefaults` keys.
 
 ```swift
-let defaultKey = DefaultKey.Name(rawValue: "key")!
+let defaultKey = DefaultKey<String>("key")
 ```
 
 ### Retrieving a stored value
 
 ```swift
 // Get the string value for the key. The method returns an Optional
-let storedString: String? = UserDefaults.standard.get(for: defaultKey)
+let storedString = UserDefaults.standard.get(for: defaultKey)
 ```
 
 Or:
@@ -79,7 +80,7 @@ Or:
 var stringDefaults = Defaults<String>.standard
 
 // Get the string value for the key. Returns an Optional
-let storedValue = stringDefaults[defaultKey]    // storedValue is a String?
+let storedValue = stringDefaults[defaultKey]
 ```
 
 ### Storing a new value
@@ -93,6 +94,12 @@ Or:
 ```swift
 // Store a new value
 stringDefaults[defaultKey] = "hello"
+```
+
+Here is the power of `Defaults.swift`: you can store different types for the same key
+```swift
+UserDefaults.standard.set(10, for: defaultKey)  // this won't compile
+stringDefaults[defaultKey] = 10                 // this won't compile too
 ```
 
 ### Removing a value
@@ -109,6 +116,50 @@ Or:
 ```swift
 // Delete the value from the storage
 stringDefaults[defaultKey] = nil
+```
+
+## Migration
+
+### Migration from 1.x to 2.0.0
+
+#### Compile fixes
+The `DefaultKey` structure is now generic. Before you declared
+
+```swift
+let key = DefaultKey.Name(rawValue: "YOUR_KEY")!
+```
+
+Now, for a more type safety, you have to declare the type the key should hold.
+The internal struct `Name` doesn't exist anymore
+```swift
+let key = DefaultKey<String>("YOUR_KEY")
+```
+
+#### Convenience methods
+If you want to display, somehow, the key name in your code, you can replace
+
+```swift
+let key = yourDefaultKeyName.rawValue
+```
+
+to:
+```swift
+let key = yourDefaultKey.name
+```
+
+You can still compare two differents key by using the `==` operator.
+Pay attention that the application won't compile if you're going to compare two
+`DefaultKey` with different generic type. For example
+
+```swift
+let key = DefaultKey<String>("key")
+let aKey = DefaultKey<Int>("key")
+let otherKey = DefaultKey<String>("a")
+let anotherKey = key
+
+key == aKey         // this won't compile because they hold different types
+key == otherKey     // this will return false because the name is different
+key == anotherKey   // this will return true
 ```
 
 ## License

--- a/Sources/Defaults.swift
+++ b/Sources/Defaults.swift
@@ -9,28 +9,29 @@
 import Foundation
 
 // MARK: - DefaultKey declaration
-public struct DefaultKey {}
 
-// MARK: - DefaultKey.Name support
-public extension DefaultKey {
-    public struct Name: RawRepresentable, Equatable {
-        public var rawValue: String
-        
-        public init?(rawValue: String) {
-            self.rawValue = rawValue
-        }
+/// The structure define as much as it can the UserDefaults key.
+///
+/// It contains the name and the type informations.
+public struct DefaultKey<A>: Equatable {
+    public var name: String
+    
+    public init(_ name: String) {
+        self.name = name
     }
 }
 
-// MARK: - DefaultKey.Name Equatable conformance
-/// Compares two `DefaultKey.Name` instances
+
+/// The `DefaultKey` structure can be compared with other `DefaultKey` structs.
 ///
-/// - parameter lhs: First instance
-/// - parameter rhs: Second instance
+/// - Note: Only `DefaultKey` with the same generic type are allowed to be compared
+/// - parameter lhs: A `DefaultKey`
+/// - parameter rhs: Other `DefaultKey`
 ///
-/// - returns: `true` if their `rawValue` are the same, otherwise `false`
-public func ==(lhs: DefaultKey.Name, rhs: DefaultKey.Name) -> Bool {
-    return lhs.rawValue == rhs.rawValue
+/// - returns: `true` if the generic type and the name are the same,
+///             otherwise `false`.
+public func ==<T>(lhs: DefaultKey<T>, rhs: DefaultKey<T>) -> Bool {
+    return lhs.name == rhs.name
 }
 
 // MARK: - UserDefaults helpers
@@ -41,8 +42,8 @@ public extension UserDefaults {
     /// - parameter key: The key
     ///
     /// - returns: The stored value, if there is, otherwise `nil`
-    public func get<T>(for key: DefaultKey.Name) -> T? {
-        return UserDefaults.standard.value(forKey: key.rawValue) as? T
+    public func get<T>(for key: DefaultKey<T>) -> T? {
+        return UserDefaults.standard.value(forKey: key.name) as? T
     }
     
     /// Get a value stored in the `standard` `UserDefaults` or a default value
@@ -51,8 +52,8 @@ public extension UserDefaults {
     /// - parameter defaultValue: A default value
     ///
     /// - returns: The stored value, if there is, otherwise the default one
-    public func get<T>(for key: DefaultKey.Name, or defaultValue: T) -> T {
-        return (UserDefaults.standard.value(forKey: key.rawValue) as? T) ?? defaultValue
+    public func get<T>(for key: DefaultKey<T>, or defaultValue: T) -> T {
+        return (UserDefaults.standard.value(forKey: key.name) as? T) ?? defaultValue
     }
     
     /// Set a new value in the `standard` `UserDefaults`.
@@ -61,9 +62,9 @@ public extension UserDefaults {
     ///
     /// - parameter value: The value. It can be `nil`
     /// - parameter key:   The key
-    public func set(_ value: Any?, for key: DefaultKey.Name) {
+    public func set<T>(_ value: T?, for key: DefaultKey<T>) {
         if let value = value {
-            UserDefaults.standard.setValue(value, forKey: key.rawValue)
+            UserDefaults.standard.setValue(value, forKey: key.name)
             UserDefaults.standard.synchronize()
         } else {
             UserDefaults.standard.removeValue(for: key)
@@ -73,8 +74,8 @@ public extension UserDefaults {
     /// Remove a value in the `standard` `UserDefaults` for the specific key
     ///
     /// - parameter key: The key
-    public func removeValue(for key: DefaultKey.Name) {
-        UserDefaults.standard.removeObject(forKey: key.rawValue)
+    public func removeValue<T>(for key: DefaultKey<T>) {
+        UserDefaults.standard.removeObject(forKey: key.name)
         UserDefaults.standard.synchronize()
     }
 }
@@ -102,7 +103,7 @@ public enum Defaults<ValueType> {
     /// - parameter value: The default value
     ///
     /// - returns: The value stored, otherwise the default one
-    public subscript(key: DefaultKey.Name, or value: ValueType) -> ValueType {
+    public subscript(key: DefaultKey<ValueType>, or value: ValueType) -> ValueType {
         get {
             return _userDefaults.get(for: key, or: value)
         }
@@ -113,7 +114,7 @@ public enum Defaults<ValueType> {
     /// - parameter key: The key
     ///
     /// - returns: The value stored or the new Defaults instance
-    public subscript(key: DefaultKey.Name) -> ValueType? {
+    public subscript(key: DefaultKey<ValueType>) -> ValueType? {
         get {
             return _userDefaults.get(for: key)
         }


### PR DESCRIPTION
Now the `DefaultKey` structure is generic and doesn't contain anymore the nested type `Name`.

See [issue-1](https://github.com/dalu93/Defaults/issues/1)
